### PR TITLE
Clean up README.markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ developer-friendly. It is safe to apply these filters like so:
 el.innerHTML = (
    "<a href=" + xssFilters.uriInUnquotedAttr(url) + ">" +
    xssFilters.uriInHTMLData(url) + 
-   "</a>"
+   "</a>";
 ```
 
-In this example, the traditional wisdom of blindly escapes
+In this example, the traditional wisdom of blindly escaping
 the five well-known characters (```&<>'"```) wouldn't stop
-XSS. (E.g, when url is ```javascript:alert(1)``` or 
-``` onclick=alert(1)```).`
+XSS. (E.g, when url is equal to ```javascript:alert(1)``` or 
+```onclick=alert(1)``` ).
 
 - ***Just Sufficient* escaping.** Escapes the *minimal* set of
 characters to thwart JavaScript executions, thus preventing
@@ -55,8 +55,8 @@ Install the [xss-filters npm](https://www.npmjs.com/package/xss-filters), and in
 npm install xss-filters --save
 ```
 
-Require the secure filters, and you can then use it with your favorite
-template engine.
+Require *xss-filters*, and you can then use it with your favorite
+template engine. Or just use it directly:
 
 ```javascript
 var express = require('express');
@@ -89,12 +89,18 @@ API Documentations
 
 **WARNINGS**
 
-(1) Filters MUST be applied only to UTF-8-encoded documents.
+(1) Filters **MUST ONLY** be applied to UTF-8-encoded documents.
 
-(2) DO NOT apply any filters inside any scriptable contexts,
+(2) **DON'T** apply any filters inside any scriptable contexts,
 i.e., `<script>`, `<style>`, `<embed>`, and `<svg>` tags as
 well as `style=""` and `onXXX=""` (e.g., `onclick`) attributes.
-A workaround is to use `<input id="strJS" value="{{{inHTMLData data}}}">`
+It is **never** safe to permit untrusted input inside a scriptable
+context.
+
+A workaround, if you need to include data for JS to use, is to use
+```html
+<input id="strJS" value="{{{inHTMLData data}}}">
+```
 and retrieve your data with `document.getElementById('strJS').value`.
 
 There are five context-sensitive filters for generic input:
@@ -106,7 +112,7 @@ There are five context-sensitive filters for generic input:
 
 > Here we use {{{ }}} to indicate output expression to ease illustrations
 
-**Whenever possible, apply a more specific filter** that best describes your context and data:
+**Whenever possible, apply the most specific filter** that describes your context and data:
 
 | Input\Context | HTMLData | HTMLComment | SingleQuotedAttr | DoubleQuotedAttr | UnQuotedAttr |
 | -------- | -------- | -------- | -------- | -------- | -------- |
@@ -124,8 +130,8 @@ Contributing
 To contribute, make changes in `src/` and `tests/`, and then do:
 
 ```sh
-npm test             # run the tests
-npm run-script docs  # build the docs
+npm test              # run the tests
+npm run-script docs   # build the docs
 npm run-script build  # build the minified version
 ```
 
@@ -139,3 +145,5 @@ License
 This software is free to use under the Yahoo BSD license.
 See the [LICENSE file](./LICENSE) for license text and
 copyright information.
+
+[html5]: https://whatwg.org/html5

--- a/README.md
+++ b/README.md
@@ -1,30 +1,63 @@
 Secure XSS Filters
-=================
-Just sufficient output filtering to prevent XSS!
+==================
+
+*Just sufficient* output filtering to prevent XSS, without
+extra `&amp;amp;lt;`s.
 
 ## Goals
 
-- **More Secure** - Context-dependent output filters that are developer-friendly and easy to comprehend. It is secure to apply our filters like so: ```el.innerHTML = "<a href=" + xssFilters.uriInUnquotedAttr(url) + ">" + xssFilters.uriInHTMLData(url) + "</a>"```. In this example, the traditional wisdom of blindly encoding the five well-known characters (```&``` ```<``` ```>``` ```'``` ```"```) would however fail in stopping XSS (i.e., when url is ```javascript:alert(1)``` or ``` onclick=alert(1)```).
-- **Just Sufficient Encoding** - Encode the *minimal* set of characters to thwart JavaScript executions, thus preventing XSS attacks while keeping most characters intact. Say goodbye to double-encoding problems such as '&amp;amp;lt;', as resulted often by traditional filters!!
+- **More Secure.** Context-dependent output filters that are
+developer-friendly. It is safe to apply these filters like so:
+
+```javascript
+el.innerHTML = (
+   "<a href=" + xssFilters.uriInUnquotedAttr(url) + ">" +
+   xssFilters.uriInHTMLData(url) + 
+   "</a>"
+```
+
+In this example, the traditional wisdom of blindly escapes
+the five well-known characters (```&<>'"```) wouldn't stop
+XSS. (E.g, when url is ```javascript:alert(1)``` or 
+``` onclick=alert(1)```).`
+
+- ***Just Sufficient* escaping.** Escapes the *minimal* set of
+characters to thwart JavaScript executions, thus preventing
+XSS attacks while keeping most characters intact. Say goodbye
+to double-encoding problems such as '&amp;amp;lt;', as often
+caused by traditional filters.
 
 ![alt Visualizing the concept of just sufficient encoding](https://ierg4210.github.io/web/images/xss-filters/xss-filters.png)
-Figure 1. Encoding decision based on the HTML5 specification to achieve the idea of "just sufficient encoding"
+Figure 1. "Just sufficient" encoding based on the HTML5 spec.
 
-## Designs
+## Design
 
-- **Standard Compliant** - Stemmed from the modern HTML 5 Specification, we re-design how XSS filters should be applied. The general principle is to encode characters that are specific to each non-scriptable output context. Therefore, untrusted input characters are sanitized by context-sensitive encoding that will not break out from the containing context. The approach stops any malicious inputs from executed as scripts, as well as solving the age-old problem of over/double-encoding.
-- **Carefully Designed** - Every filter is heavily scrutinized by Yahoo Security Engineers. The specific sets of characters that require encoding are minimized so as to preserve usability to the greatest extent.
+- **Standards compliant.** - We redesigned XSS filters based
+on the modern [HTML 5 spec][html5]. The principle is to escape
+characters specific to each non-scriptable output context. Thus,
+untrusted input, once sanitized by context-sensitive escaping,
+can't break out from the containing context. This approach stops
+malicious inputs from being executed as scripts, and also prevents
+the age-old problem of over/double-encoding.
+
+- **Carefully designed.** - Every filter has been heavily scrutinized
+by Yahoo Security Engineers. The specific sets of characters that
+require encoding have been minimized to preserve usability to the
+greatest extent possible.
 
 ## Quick Start
 
 ### Server-side (nodejs)
 
-Install the [xss-filters npm](https://www.npmjs.com/package/xss-filters), and include it as your project's dependency.
-```
-$ npm install xss-filters --save
+Install the [xss-filters npm](https://www.npmjs.com/package/xss-filters), and include it as a dependency for your project:
+
+```sh
+npm install xss-filters --save
 ```
 
-Require the secure filters, and you can then use it with/out your favorite templating engine.
+Require the secure filters, and you can then use it with your favorite
+template engine.
+
 ```javascript
 var express = require('express');
 var app = express();
@@ -38,7 +71,11 @@ app.get('/', function(req, res){
 
 ### Client-side (browser)
 
-Simply download the latest minified version of JavaScript file directly from the [`dist/`](./dist) folder. Embed it to your HTML file, and all filters are exposed to a global object called `xssFilters`.
+Simply download the latest minified version from the
+[dist/](./dist) folder. Embed it in your HTML file,
+and all filters are available in a global object
+called `xssFilters`.
+
 ```html
 <script src="dist/xss-filters.min.js"></script>
 <script>
@@ -49,7 +86,16 @@ document.write('<h1> Hello, ' + xssFilters.inHTMLData(firstname) + '!</h1>')
 
 API Documentations
 -------
-**DISCLAIMER**: (1) Filters are applied in UTF-8 documents. (2) DO NOT apply any filters inside any scriptable contexts, i.e., `<script>`, `<style>`, `<embed>`, and `<svg>` tags as well as `style=""` and `onXXX=""` (e.g., `onclick`) attributes. A workaround is to use `<input id="strJS" value="{{{inHTMLData data}}}">` and retrieve your data with `document.getElementById('strJS').value`.
+
+**WARNINGS**
+
+(1) Filters MUST be applied only to UTF-8-encoded documents.
+
+(2) DO NOT apply any filters inside any scriptable contexts,
+i.e., `<script>`, `<style>`, `<embed>`, and `<svg>` tags as
+well as `style=""` and `onXXX=""` (e.g., `onclick`) attributes.
+A workaround is to use `<input id="strJS" value="{{{inHTMLData data}}}">`
+and retrieve your data with `document.getElementById('strJS').value`.
 
 There are five context-sensitive filters for generic input:
  - `<div>``{{{inHTMLData data}}}``</div>`
@@ -70,16 +116,18 @@ There are five context-sensitive filters for generic input:
 | URI Component | uriComponentInHTMLData() | uriComponentInHTMLComment() | uriComponentInSingleQuotedAttr() | uriComponentInDoubleQuotedAttr() | uriComponentInUnQuotedAttr() |
 | URI Fragment | uriFragmentInHTMLData() | uriFragmentInHTMLComment() | uriFragmentInSingleQuotedAttr() | uriFragmentInDoubleQuotedAttr() | uriFragmentInUnQuotedAttr() |
 
-Check out the [documentations](../../wiki) for more details.
+Check out the [documentation](../../wiki) for more details.
 
-
-
-Contribute
+Contributing
 -------
-To contribute, you will make changes in `src/` and `tests/`, followed by the following commands:
-- ```$ npm test``` to run the tests
-- ```$ npm run-script docs``` to build the docs
-- ```$ npm run-script build``` to build the standalone JavaScript for client-side use
+
+To contribute, make changes in `src/` and `tests/`, and then do:
+
+```sh
+npm test             # run the tests
+npm run-script docs  # build the docs
+npm run-script build  # build the minified version
+```
 
 Build
 -----
@@ -89,4 +137,5 @@ License
 -------
 
 This software is free to use under the Yahoo BSD license.
-See the [LICENSE file](./LICENSE) for license text and copyright information.
+See the [LICENSE file](./LICENSE) for license text and
+copyright information.


### PR DESCRIPTION
Various typos, use of "encoding" for "escaping", and some minor style changes.