### PR TITLE
improve release workflow

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,6 +80,24 @@ module.exports = function(grunt) {
         }
       }
     },
+    bump: {
+      options: {
+        files: [ 'package.json', 'bower.json'],
+        updateConfigs: ['pkg'],
+        commit: true,
+        commitMessage: 'Release v%VERSION%',
+        commitFiles: ['package.json', 'bower.json', 'dist/.'],
+        createTag: true,
+        tagName: 'v%VERSION%',
+        tagMessage: 'Version %VERSION%',
+        push: true,
+        pushTo: 'origin',
+        gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
+        globalReplace: false,
+        prereleaseName: false,
+        regExp: false
+      }
+    },
     clean: {
       all: ['artifacts', 'node_modules', 'bower_components']
     }
@@ -91,10 +109,12 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-jsdoc');
+  grunt.loadNpmTasks('grunt-bump');
 
   grunt.registerTask('test', ['jshint', 'mocha_istanbul']);
   grunt.registerTask('dist', ['browserify', 'uglify'])
   grunt.registerTask('docs', ['jsdoc']);
   grunt.registerTask('default', ['test', 'dist']);
+  grunt.registerTask('release', ['bump-only', 'dist', 'bump-commit']);
 
 };

--- a/package.json
+++ b/package.json
@@ -1,12 +1,7 @@
 {
   "name": "xss-filters",
   "version": "1.2.4",
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "https://github.com/yahoo/xss-filters/blob/master/LICENSE"
-    }
-  ],
+  "license": "SEE LICENSE IN LICENSE",
   "description": "Secure XSS Filters - Just sufficient output filtering to prevent XSS!",
   "author": "Nera Liu <neraliu@yahoo-inc.com>, Adonis Fung <adon@yahoo-inc.com> and Albert Yu <albertyu@yahoo-inc.com>",
   "contributors": [
@@ -48,6 +43,7 @@
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.8.0",
+    "grunt-bump": "^0.3.1",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.7.0",


### PR DESCRIPTION
thereafter, the task of releasing a new version becomes easier.

To release a version
 - `grunt release` will automatically set version z=z+1 as in x.y.z
 - `grunt release minor` will automatically set version y = y+1, z = 0 as in x.y.z
 - `grunt release major` will automatically set version x = x+1, y = z = 0 as in x.y.z

p.s. append ` --dry-run` if needed for a test. 

What it does:
 - the new version number will be written into both package.json and bower.json
 - call `grunt dist` to generate a new file (with proper version #)
 - `git commit package.json, bower.json, dist/. -m "Release vx.y.z"`
 - `git tag -a vx.y.z -m "Version x.y.z"`
 - `git push origin && git push origin --tags`
